### PR TITLE
添加自定义渲染布局文件参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ douban:
 - **quote**: 写在页面开头的一段话,支持html语法。
 - **option**: 该页面额外的 Front-matter 配置，参考[Hexo 文档](https://hexo.io/docs/front-matter.html)。无特别需要，留空即可。
 - **timeout**: 爬取数据的超时时间，默认是 10000ms ,如果在使用时发现报了超时的错(ETIMEOUT)可以把这个数据设置的大一点。
-- **customize_layout**: 自定义布局文件，默认值为post，即使用//theme/hexo-theme/layout/post.ejs
+- **customize_layout**: 自定义布局文件。默认值为page，post,若//theme/hexo-theme/layout/page.ejs不存在则使用post.ejs
 
 如果只想显示某一个页面(比如movie)，那就把其他的配置项注释掉即可。
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ douban:
   builtin: false
   item_per_page: 10
   meta_max_line: 4
+  customize_layout: post
   book:
     path: books/index.html
     title: 'This is my book title'
@@ -60,9 +61,17 @@ douban:
 - **quote**: 写在页面开头的一段话,支持html语法。
 - **option**: 该页面额外的 Front-matter 配置，参考[Hexo 文档](https://hexo.io/docs/front-matter.html)。无特别需要，留空即可。
 - **timeout**: 爬取数据的超时时间，默认是 10000ms ,如果在使用时发现报了超时的错(ETIMEOUT)可以把这个数据设置的大一点。
+- **customize_layout**: 自定义布局文件，默认值为post，即使用//theme/hexo-theme/layout/post.ejs
 
 如果只想显示某一个页面(比如movie)，那就把其他的配置项注释掉即可。
 
+customize_layout参数适用于GitHub action等自动部署方式下不便于修改本插件渲染douban页面布局文件的情况。
+
+  参数使用示例：
+  ~~~
+  customize_layout: douban # 指定//theme/hexo-theme/layout/douban.ejs文件渲染douban页面
+  ~~~
+      
 ## 使用
 
 **展示帮助文档**

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -33,6 +33,11 @@ module.exports = async function (locals) {
     if (config.douban.meta_max_line) {
         meta_max_line = config.douban.meta_max_line
     }
+    
+    let customize_layout = 'post'
+    if (config.douban.customize_layout) {
+        customize_layout = config.douban.customize_layout
+    }
 
     const startTime = new Date().getTime();
 
@@ -62,7 +67,7 @@ module.exports = async function (locals) {
                 content: renderedData,
                 slug: `${type}s`
             }, config.douban[type].option),
-            layout: ['page', 'post']
+            layout: ['page', customize_layout]
         };
     })
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -34,7 +34,7 @@ module.exports = async function (locals) {
         meta_max_line = config.douban.meta_max_line
     }
     
-    let customize_layout = 'post'
+    let customize_layout = 'page'
     if (config.douban.customize_layout) {
         customize_layout = config.douban.customize_layout
     }
@@ -67,7 +67,7 @@ module.exports = async function (locals) {
                 content: renderedData,
                 slug: `${type}s`
             }, config.douban[type].option),
-            layout: ['page', customize_layout]
+            layout: [customize_layout, 'post']
         };
     })
 };


### PR DESCRIPTION
本插件默认post对douban页面进行渲染，在使用不同主题时，需要根据实际情况选择不同的模板对douban页面渲染，本地部署可以通过修改node_modules\hexo-douban\generator.js文件中layout: ['page', ’post‘]指定模板对douban页面渲染，而GitHub action等远程部署方式则不便于修改，故作此修改，添加customize_layout参数以便远程自动部署方式的自定义渲染。