### PR TITLE
修正 .hexo-douban-comment的样式名

### DIFF
--- a/lib/templates/index.css
+++ b/lib/templates/index.css
@@ -58,7 +58,7 @@
     margin-top: 8px;
 }
 
-.hexo-douban-comments {
+.hexo-douban-comment {
     font-size: 12px;
 }
 


### PR DESCRIPTION
将index.css中 .hexo-douban-comments 修正为  .hexo-douban-comment。

index.ejs中comment注册的类名是 `.hexo-douban-comment`，
但是index.css中comment的类名是 `.hexo-douban-comments`，
